### PR TITLE
Make sure onExit is called if there is no audio stream

### DIFF
--- a/gpuv/src/main/java/com/daasuu/gpuv/camerarecorder/GPUCameraRecorder.java
+++ b/gpuv/src/main/java/com/daasuu/gpuv/camerarecorder/GPUCameraRecorder.java
@@ -230,7 +230,7 @@ public class GPUCameraRecorder {
             if (encoder instanceof MediaAudioEncoder && audioStopped) {
                 audioExitReady = true;
             }
-            if (videoExitReady && audioExitReady) {
+            if (videoExitReady && (audioExitReady || mute)) {
                 cameraRecordListener.onVideoFileReady();
             }
         }


### PR DESCRIPTION
Pull request #70 introduced the problem that onExit would never be called, if the audio stream was muted.