### PR TITLE
Fix issue when rendering landscape video

### DIFF
--- a/gpuv/src/main/java/com/daasuu/gpuv/camerarecorder/capture/EncodeRenderHandler.java
+++ b/gpuv/src/main/java/com/daasuu/gpuv/camerarecorder/capture/EncodeRenderHandler.java
@@ -62,7 +62,7 @@ public class EncodeRenderHandler implements Runnable {
         final EncodeRenderHandler handler = new EncodeRenderHandler(
                 flipVertical,
                 flipHorizontal,
-                fileHeight / fileWidth,
+                fileHeight > fileWidth ? fileHeight / fileWidth : fileWidth / fileHeight,
                 viewAspect,
                 fileWidth,
                 fileHeight,


### PR DESCRIPTION
There is an issue when rendering a video in landscape. 

The `viewAspect` value is only considering that height is always higher than width.